### PR TITLE
Move results_controller#create to api::results_controller#create, and allow users to manage api tokens

### DIFF
--- a/app/controllers/api/results_controller.rb
+++ b/app/controllers/api/results_controller.rb
@@ -1,0 +1,44 @@
+module Api
+  class ResultsController < ApiController
+    def create
+      render :ok, json: create_results
+    end
+
+    private
+
+    def create_results
+      result_data.map do |result_json|
+        result = results.create! \
+          tag: result_tag,
+          example_name: result_json['example_name'],
+          example_location: result_json['example_location']
+
+        create_queries(result, result_json['queries']) if result_json['queries']
+
+        result
+      end
+    end
+
+    def create_queries(result, result_queries)
+      result_queries.each do |result_query|
+        result.queries.build(statement: result_query).save!
+      end
+    end
+
+    def project
+      @project ||= Project.find params[:project_id]
+    end
+
+    def results
+      project.results.reorder created_at: :asc
+    end
+
+    def result_data
+      params["result_data"]
+    end
+
+    def result_tag
+      params["tag"]
+    end
+  end
+end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,0 +1,12 @@
+class ApiController < ApplicationController
+  before_action :authentication_api_token!
+
+  private
+
+  def authentication_api_token!
+    authenticate_or_request_with_http_token do |token, _options|
+      decoded_token = Base64.strict_decode64 token
+      @current_user = User.find_by api_token: decoded_token
+    end
+  end
+end

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -2,10 +2,6 @@ class ResultsController < BackendController
   skip_before_action :verify_authenticity_token, only: [:create]
   skip_before_action :authenticate_user!, only: [:create]  # TODO: check for API token
 
-  def create
-    render :ok, json: create_results
-  end
-
   def index
     @results = current_user.results.where(id: params[:id])
   end
@@ -29,41 +25,6 @@ class ResultsController < BackendController
   # end
 
   private
-
-  def project
-    @project ||= Project.find params[:project_id]
-  end
-
-  def results
-    project.results.reorder created_at: :asc
-  end
-
-  def create_results
-    result_data.map do |result_json|
-      result = results.create! \
-        tag: result_tag,
-        example_name: result_json['example_name'],
-        example_location: result_json['example_location']
-
-      create_queries(result, result_json['queries']) if result_json['queries']
-
-      result
-    end
-  end
-
-  def create_queries(result, result_queries)
-    result_queries.each do |result_query|
-      result.queries.build(statement: result_query).save!
-    end
-  end
-
-  def result_data
-    params["result_data"]
-  end
-
-  def result_tag
-    params["tag"]
-  end
 
   def compare_with_latest_of_tag
     params["compare_with_latest_of_tag"]

--- a/app/controllers/token_controller.rb
+++ b/app/controllers/token_controller.rb
@@ -1,0 +1,17 @@
+class TokenController < BackendController
+  def show
+    generate_api_token! if current_user.api_token.blank?
+    @user = current_user
+  end
+
+  def create
+    generate_api_token!
+    render :show
+  end
+
+  private
+
+  def generate_api_token!
+    current_user.update! api_token: SecureRandom.random_bytes(User::API_TOKEN_LENGTH)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ActiveRecord::Base
+  API_TOKEN_LENGTH = 64
+
   devise :omniauthable, omniauth_providers: [:github]
 
   has_many :projects

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,7 @@
     <% if current_user.present? %>
       <%= link_to 'Sign out', destroy_user_session_path %>
       <%= link_to "My projects", projects_path %>
+      <%= link_to "My API token", token_show_path %>
     <% end %>
 
 

--- a/app/views/token/show.html.erb
+++ b/app/views/token/show.html.erb
@@ -1,0 +1,13 @@
+<p>
+Your API token is: <input type="text" readonly="readonly" value="<%= Base64.encode64(current_user.api_token) %>" size="<%= User::API_TOKEN_LENGTH * 1.5 %>"></input>
+<p>
+
+<p>
+You can use HTTP token authentication to authenticate yourself. The regressor-rspec gem does the heavy lifting for you, read the documentation.
+</p>
+<p>
+This token gives complete access to all the projects that you own.
+</p>
+
+<%= link_to "Generate new API token", token_create_path, method: :post %>
+(Careful! You cannot undo this operation.)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,11 @@ Rails.application.routes.draw do
   end
 
   resources :results, only: [:create, :index]
+
   get '/results/compare', to: 'results#compare_view', as: 'result_compare'
+
+  get '/token', to: 'token#show', as: 'token_show'
+  post '/token', to: 'token#create', as: 'token_create'
 
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
   devise_scope :user do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,8 @@ Rails.application.routes.draw do
     resources :examples
   end
 
-  resources :results, only: [:create, :index]
+  resources :results, only: :index
+  resources :results, module: 'api', only: :create
 
   get '/results/compare', to: 'results#compare_view', as: 'result_compare'
 

--- a/db/migrate/20151209152117_add_api_token_to_user.rb
+++ b/db/migrate/20151209152117_add_api_token_to_user.rb
@@ -1,0 +1,9 @@
+class AddApiTokenToUser < ActiveRecord::Migration
+  def up
+    add_column :users, :api_token, :binary
+  end
+
+  def down
+    remove_column :users, :api_token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151110160748) do
+ActiveRecord::Schema.define(version: 20151209152117) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,6 +77,7 @@ ActiveRecord::Schema.define(version: 20151110160748) do
     t.string   "provider"
     t.string   "uid"
     t.string   "api_key"
+    t.binary   "api_token"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/spec/controllers/api/results_controller_spec.rb
+++ b/spec/controllers/api/results_controller_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe Api::ResultsController, :type => :controller do
+  let(:body_json) { JSON.parse subject.body }
+  let(:project) { create :project }
+
+  describe '.create' do
+    let(:compare_with_latest_of_tag) { nil }
+
+    let(:result_params) do
+      {
+        "tag" => "pull-request-1",
+        "result_data" => [
+          {
+            "example_location" => "spec/integration/users/user_spec.rb",
+            "example_name" => "user change user version 7 uses the correct timestamp",
+            "queries" => [
+              'select * from users',
+              'select * from teams where id in (?)'
+            ],
+          },
+          {
+            "example_location" => "spec/integration/users/user_spec.rb",
+            "example_name" => "user change user version 7 updates user create report rate limit privilege",
+            "queries" => [
+              'select * from teams where id in (?)',
+              'select * from users'
+            ]
+          },
+        ]
+      }
+    end
+
+    subject { post :create, result_params.merge(project_id: project.id) }
+
+    include_examples 'authenticated using api token'
+
+    context 'authorized', :auth_using_api_token do
+      it 'creates the results' do
+        expect { subject }.to change { project.results.count }.by(2)
+        result = project.results.first
+        expect(result.tag).to eq 'pull-request-1'
+      end
+
+      it 'create a result even no queries are given' do
+        result_params['result_data'].first.delete 'queries'
+        expect { subject }.to change { Result.count }.by(2)
+      end
+
+      it 'without a project' do
+        expect { post(:create, result_params) }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+  end
+end

--- a/spec/controllers/projects/results_controller_spec.rb
+++ b/spec/controllers/projects/results_controller_spec.rb
@@ -1,55 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ResultsController, :type => :controller do
-  let(:body_json) { JSON.parse subject.body }
   let(:project) { create :project }
-
-  describe '.create' do
-    let(:compare_with_latest_of_tag) { nil }
-
-    let(:result_params) do
-      {
-        "tag" => "pull-request-1",
-        "result_data" => [
-          {
-            "example_location" => "spec/integration/users/user_spec.rb",
-            "example_name" => "user change user version 7 uses the correct timestamp",
-            "queries" => [
-              'select * from users',
-              'select * from teams where id in (?)'
-            ],
-          },
-          {
-            "example_location" => "spec/integration/users/user_spec.rb",
-            "example_name" => "user change user version 7 updates user create report rate limit privilege",
-            "queries" => [
-              'select * from teams where id in (?)',
-              'select * from users'
-            ]
-          },
-        ]
-      }
-    end
-
-    subject { post :create, result_params.merge(project_id: project.id) }
-
-    it { expect(subject).to have_http_status :success }
-
-    it 'creates the results' do
-      expect { subject }.to change { project.results.count }.by(2)
-      result = project.results.first
-      expect(result.tag).to eq 'pull-request-1'
-    end
-
-    it 'create a result even no queries are given' do
-      result_params['result_data'].first.delete 'queries'
-      expect { subject }.to change { Result.count }.by(2)
-    end
-
-    it 'without a project' do
-      expect { post(:create, result_params) }.to raise_error ActiveRecord::RecordNotFound
-    end
-  end
 
   describe '.compare_view' do
     it 'shows the differences between the queries two results' do

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,5 +1,11 @@
 FactoryGirl.define do
   factory :user do
     sequence(:email) { |n| "user_#{n}@example.com" }
+
+    api_token SecureRandom.random_bytes(User::API_TOKEN_LENGTH)
+
+    trait :without_api_token do
+      api_token nil
+    end
   end
 end

--- a/spec/shared_api.rb
+++ b/spec/shared_api.rb
@@ -1,0 +1,18 @@
+RSpec.shared_context 'authorized with api_token', :auth_using_api_token do
+  let(:user_with_api_token) { create :user }
+  before do
+    token = ActionController::HttpAuthentication::Token
+      .encode_credentials(Base64.strict_encode64 user_with_api_token.api_token)
+    @request.env['HTTP_AUTHORIZATION'] = token
+  end
+end
+
+RSpec.shared_examples 'authenticated using api token' do
+  context 'unauthenticated' do
+    it { expect(subject).to have_http_status :unauthorized }
+  end
+
+  context 'authenticated', :auth_using_api_token do
+    it { expect(subject).to have_http_status :success }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -86,3 +86,5 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 =end
 end
+
+require 'shared_api.rb'


### PR DESCRIPTION
- Users are given a 64 byte API Token, HTTP token authentication is used to provide the token.
- Effectively, the token is used to log in as a user
- API controllers now live in `controllers/api`

This is a breaking change, once this in master I'll modify the regressor branch of rspec-regression to use a token and `/api` route.
