### PR TITLE
Compare result sets w/ API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 [![Circle CI](https://circleci.com/gh/Willianvdv/regressor.svg?style=svg)](https://circleci.com/gh/Willianvdv/regressor)
 
+# How it works (by example)
 
-# Note to self
+* There are two CI jobs: develop and master
 
-How it works:
+* Master stores results
+* Develop stores and compares with master
 
-	* There are two CI jobs: develop and master
+* Master uses the tag 'master'
+* Develop uses the tag `git rev-parse HEAD` (current commit hash)
+* Comparison is between `current_commit_hash <-> master`
 
-	* Master stores results
-	* Develop stores and compares with master
-
-	* Master uses the tag 'master'
-	* Develop uses the tag `git rev-parse HEAD` (current commit hash)
-	* Comparison is between `current_commit_hash <-> master`
+* storage is handled by rspec-regression gem
+* comparison is done via web interface, or by using the API
+  * `/api/results/compare_latest_of_tags.{json/text}?left_tag=GIT_COMMIT&right_tag=master`
+  * format `text` renders markdown as plaintext

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 [![Circle CI](https://circleci.com/gh/Willianvdv/regressor.svg?style=svg)](https://circleci.com/gh/Willianvdv/regressor)
 
+!!!
+You need the `raas` branch from [rspec_regressor](https://github.com/regressionbv/rspec_regression)
+!!!
+
 # How it works (by example)
 
 * There are two CI jobs: develop and master

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 [![Circle CI](https://circleci.com/gh/Willianvdv/regressor.svg?style=svg)](https://circleci.com/gh/Willianvdv/regressor)
+
+
+# Note to self
+
+How it works:
+
+	* There are two CI jobs: develop and master
+
+	* Master stores results
+	* Develop stores and compares with master
+
+	* Master uses the tag 'master'
+	* Develop uses the tag `git rev-parse HEAD` (current commit hash)
+	* Comparison is between `current_commit_hash <-> master`

--- a/app/controllers/api/results_controller.rb
+++ b/app/controllers/api/results_controller.rb
@@ -4,11 +4,6 @@ module Api
       render :ok, json: create_results
     end
 
-    def index
-      # todo rename route
-      compare_latest_of_tags
-    end
-
     def compare_latest_of_tags
       comper = Api::ResultsComper.new project, params[:left_tag], params[:right_tag]
 

--- a/app/controllers/api/results_controller.rb
+++ b/app/controllers/api/results_controller.rb
@@ -5,7 +5,9 @@ module Api
     end
 
     def compare_latest_of_tags
-      comper = Api::ResultsComper.new project, params[:left_tag], params[:right_tag]
+      comper = Api::ResultsComper.new project,
+        params['left_tag'],
+        params['right_tag']
 
       respond_to do |format|
         format.json { render :ok, json: comper.comparison }
@@ -35,7 +37,7 @@ module Api
     end
 
     def project
-      @project ||= current_user.projects.find params[:project_id]
+      @project ||= current_user.projects.find params['project_id']
     end
 
     def results

--- a/app/controllers/api/results_controller.rb
+++ b/app/controllers/api/results_controller.rb
@@ -7,7 +7,10 @@ module Api
     def compare_latest_of_tags
       comper = Api::ResultsComper.new project, params[:left_tag], params[:right_tag]
 
-      render :ok, json: comper.comparison
+      respond_to do |format|
+        format.json { render :ok, json: comper.comparison }
+        format.text { render :ok, text: comper.comparison_in_markdown }
+      end
     end
 
     private

--- a/app/controllers/api/results_controller.rb
+++ b/app/controllers/api/results_controller.rb
@@ -35,7 +35,7 @@ module Api
     end
 
     def project
-      @project ||= current_user.projects.find_by id: params[:project_id]
+      @project ||= current_user.projects.find params[:project_id]
     end
 
     def results

--- a/app/controllers/api/results_controller.rb
+++ b/app/controllers/api/results_controller.rb
@@ -4,10 +4,15 @@ module Api
       render :ok, json: create_results
     end
 
-    def compare_latest_of_tags
-      # grab the latest of left_tag and right_tag, and return a JSON
-      # representation of the comparison
+    def index
+      # todo rename route
+      compare_latest_of_tags
+    end
 
+    def compare_latest_of_tags
+      comper = Api::ResultsComper.new project, params[:left_tag], params[:right_tag]
+
+      render :ok, json: comper.comparison
     end
 
     private
@@ -32,7 +37,7 @@ module Api
     end
 
     def project
-      @project ||= Project.find params[:project_id]
+      @project ||= current_user.projects.find_by id: params[:project_id]
     end
 
     def results

--- a/app/controllers/api/results_controller.rb
+++ b/app/controllers/api/results_controller.rb
@@ -4,6 +4,12 @@ module Api
       render :ok, json: create_results
     end
 
+    def compare_latest_of_tags
+      # grab the latest of left_tag and right_tag, and return a JSON
+      # representation of the comparison
+
+    end
+
     private
 
     def create_results

--- a/app/helpers/api/results_comper.rb
+++ b/app/helpers/api/results_comper.rb
@@ -25,7 +25,34 @@ module Api
       end.compact
     end
 
+    def comparison_in_markdown
+      <<-ENDMARKDOWN
+      Results:
+
+      #{comparison.map { |result| result_to_markdown result }.join("\n")}
+      ENDMARKDOWN
+    end
+
     private
+
+    def result_to_markdown(result)
+      header = "* #{result['example_name']} (#{result['example_location']})"
+
+      markdown = <<-ENDMARKDOWN
+        * Queries that got added:
+          #{array_to_markdown_list(result['queries_that_got_added'])}
+        * Queries that got removed:
+          #{array_to_markdown_list(result['queries_that_got_removed'])}
+      ENDMARKDOWN
+
+      header + "\n" + markdown.indent(2)
+    end
+
+    def array_to_markdown_list(arr)
+      arr.map do |elem|
+        "* #{elem}"
+      end.join("\n")
+    end
 
     def results_left
       project.results.where tag: left_tag

--- a/app/helpers/api/results_comper.rb
+++ b/app/helpers/api/results_comper.rb
@@ -1,0 +1,63 @@
+module Api
+  class ResultsComper
+    attr_reader :project, :left_tag, :right_tag
+
+    def initialize(project, left_tag, right_tag)
+      @project = project
+      @left_tag = left_tag
+      @right_tag = right_tag
+    end
+
+    def comparison
+      results_left.map do |left_result|
+        right_result = right_result_for left_result
+        next unless right_result.present?
+
+        left_queries = queries_for left_result
+        right_queries = queries_for right_result
+
+        queries_that_got_added = array_diff left_queries, right_queries
+        queries_that_got_removed = array_diff right_queries, left_queries
+
+        next if queries_that_got_added.empty? && queries_that_got_removed.empty?
+
+        format_comparison(left_result, queries_that_got_added, queries_that_got_removed)
+      end.compact
+    end
+
+    private
+
+    def results_left
+      project.results.where tag: left_tag
+    end
+
+    def right_result_for(left_result)
+      project.results.where(
+        tag: right_tag,
+        example_name: left_result.example_name
+      ).last
+    end
+
+    def queries_for(result)
+      result.queries.order(:id).map(&:statement)
+    end
+
+    def array_diff(a, b)
+      dup_b = b.dup
+      a.reject do |item|
+        b_index = dup_b.index(item)
+        next false unless b_index
+        dup_b.delete_at b_index
+      end
+    end
+
+    def format_comparison(left_result, queries_that_got_added, queries_that_got_removed)
+      {
+        "example_name" => left_result.example_name,
+        "example_location" => left_result.example_location,
+        "queries_that_got_added" => queries_that_got_added,
+        "queries_that_got_removed" => queries_that_got_removed,
+      }
+    end
+  end
+end

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,8 +1,11 @@
 <div>
+  <p>
+    <%= link_to 'Create new project', new_project_path %>
+  </p>
+
   <ul>
     <% @projects.each do |project| %>
       <li><%= link_to project.id, project %></li>
     <% end %>
   </ul>
 </div>
-

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -5,7 +5,7 @@
 
   <ul>
     <% @projects.each do |project| %>
-      <li><%= link_to project.id, project %></li>
+      <li><%= link_to "#{project.name} (#{project.id})", project %></li>
     <% end %>
   </ul>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   resources :results, module: 'api', only: :create
 
   get '/results/compare', to: 'results#compare_view', as: 'result_compare'
+  get '/api/results/compare_latest_of_tags', module: 'api', to: 'results#compare_latest_of_tags', as: 'api_results_compare_latest_of_tags'
 
   get '/token', to: 'token#show', as: 'token_show'
   post '/token', to: 'token#create', as: 'token_create'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,9 +4,12 @@ Rails.application.routes.draw do
   end
 
   resources :results, only: :index
-  resources :results, module: 'api', only: [:create, :index]
-
   get '/results/compare', to: 'results#compare_view', as: 'result_compare'
+
+  scope 'api', module: 'api' do
+    resources :results, only: :create
+    get 'results/compare_latest_of_tags', to: 'results#compare_latest_of_tags'
+  end
 
   get '/token', to: 'token#show', as: 'token_show'
   post '/token', to: 'token#create', as: 'token_create'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,10 +4,9 @@ Rails.application.routes.draw do
   end
 
   resources :results, only: :index
-  resources :results, module: 'api', only: :create
+  resources :results, module: 'api', only: [:create, :index]
 
   get '/results/compare', to: 'results#compare_view', as: 'result_compare'
-  get '/api/results/compare_latest_of_tags', module: 'api', to: 'results#compare_latest_of_tags', as: 'api_results_compare_latest_of_tags'
 
   get '/token', to: 'token#show', as: 'token_show'
   post '/token', to: 'token#create', as: 'token_create'

--- a/spec/controllers/api/results_controller_spec.rb
+++ b/spec/controllers/api/results_controller_spec.rb
@@ -56,15 +56,15 @@ RSpec.describe Api::ResultsController, :type => :controller do
   end
 
   describe '.compare_latest_of_tags' do
-    let(:tag_left) { '123-left' }
-    let(:tag_right) { 'master-right' }
+    let(:left_tag) { '123-left' }
+    let(:right_tag) { 'master-right' }
     let(:project) { create :project }
     let(:shared_example_location) { 'spec/shared/example/location.rb' }
     let(:shared_example_name) { 'shared example name' }
     let(:format) { :json }
 
     subject do
-      get :compare_latest_of_tags, format: format, project_id: project.id, left_tag: tag_left, right_tag: tag_right
+      get :compare_latest_of_tags, format: format, project_id: project.id, left_tag: left_tag, right_tag: right_tag
     end
 
     let(:response_json) do
@@ -79,13 +79,13 @@ RSpec.describe Api::ResultsController, :type => :controller do
       describe 'format: json' do
         it 'compares left with right' do
           result_left = create :result,
-            tag: tag_left,
+            tag: left_tag,
             example_name: shared_example_name,
             example_location: shared_example_location,
             project: project
 
           result_right = create :result,
-            tag: tag_right,
+            tag: right_tag,
             example_name: shared_example_name,
             example_location: shared_example_location,
             project: project
@@ -110,12 +110,12 @@ RSpec.describe Api::ResultsController, :type => :controller do
 
         it 'compares left with right' do
           result_left = create :result,
-            tag: tag_left,
+            tag: left_tag,
             example_name: shared_example_name,
             project: project
 
           result_right = create :result,
-            tag: tag_right,
+            tag: right_tag,
             example_name: shared_example_name,
             project: project
 

--- a/spec/controllers/api/results_controller_spec.rb
+++ b/spec/controllers/api/results_controller_spec.rb
@@ -36,6 +36,8 @@ RSpec.describe Api::ResultsController, :type => :controller do
     include_examples 'authenticated using api token'
 
     context 'authorized', :auth_using_api_token do
+      let(:project) { create :project, user: user_with_api_token }
+
       it 'creates the results' do
         expect { subject }.to change { project.results.count }.by(2)
         result = project.results.first
@@ -57,6 +59,7 @@ RSpec.describe Api::ResultsController, :type => :controller do
     let(:tag_left) { '123-left' }
     let(:tag_right) { 'master-right' }
     let(:project) { create :project }
+    let(:shared_example_location) { 'spec/shared/example/location.rb' }
     let(:shared_example_name) { 'shared example name' }
     let(:format) { :json }
 
@@ -78,11 +81,13 @@ RSpec.describe Api::ResultsController, :type => :controller do
           result_left = create :result,
             tag: tag_left,
             example_name: shared_example_name,
+            example_location: shared_example_location,
             project: project
 
           result_right = create :result,
             tag: tag_right,
             example_name: shared_example_name,
+            example_location: shared_example_location,
             project: project
 
           create :query, result: result_left, statement: 'query in both'
@@ -93,7 +98,7 @@ RSpec.describe Api::ResultsController, :type => :controller do
 
           expect(response_json).to eq 'results' => [{
             'example_name' => 'shared example name',
-            'example_location' => 'spec/integration/users_v1_spec.rb',
+            'example_location' => 'spec/shared/example/location.rb',
             'queries_that_got_added' => ['new query'],
             'queries_that_got_removed' => ['removed query']
           }]

--- a/spec/controllers/api/results_controller_spec.rb
+++ b/spec/controllers/api/results_controller_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Api::ResultsController, :type => :controller do
     let(:shared_example_name) { 'shared example name' }
 
     subject do
-      get :index, project_id: project.id, left_tag: tag_left, right_tag: tag_right
+      get :compare_latest_of_tags, project_id: project.id, left_tag: tag_left, right_tag: tag_right
     end
 
     let(:response_json) do

--- a/spec/controllers/api/results_controller_spec.rb
+++ b/spec/controllers/api/results_controller_spec.rb
@@ -52,4 +52,48 @@ RSpec.describe Api::ResultsController, :type => :controller do
       end
     end
   end
+
+  describe '.compare_latest_of_tags' do
+    let(:tag_left) { '123-left' }
+    let(:tag_right) { 'master-right' }
+    let(:project) { create :project, user: user_with_api_token }
+    let(:shared_example_name) { 'shared example name' }
+
+    subject do
+      get :index, project_id: project.id, left_tag: tag_left, right_tag: tag_right
+    end
+
+    let(:response_json) do
+      JSON.parse subject.body
+    end
+
+    include_examples 'authenticated using api token'
+
+    context 'authorized', :auth_using_api_token do
+      it 'compares left with right' do
+        result_left = create :result,
+          tag: tag_left,
+          example_name: shared_example_name,
+          project: project
+
+        result_right = create :result,
+          tag: tag_right,
+          example_name: shared_example_name,
+          project: project
+
+        create :query, result: result_left, statement: 'query in both'
+        create :query, result: result_right, statement: 'query in both'
+
+        create :query, result: result_left, statement: 'new query'
+        create :query, result: result_right, statement: 'removed query'
+
+        expect(response_json).to eq 'results' => [{
+          'example_name' => 'shared example name',
+          'example_location' => 'spec/integration/users_v1_spec.rb',
+          'queries_that_got_added' => ['new query'],
+          'queries_that_got_removed' => ['removed query']
+        }]
+      end
+    end
+  end
 end

--- a/spec/shared_api.rb
+++ b/spec/shared_api.rb
@@ -1,5 +1,7 @@
 RSpec.shared_context 'authorized with api_token', :auth_using_api_token do
   let(:user_with_api_token) { create :user }
+  let(:project) { create :project, user: user_with_api_token }
+
   before do
     token = ActionController::HttpAuthentication::Token
       .encode_credentials(Base64.strict_encode64 user_with_api_token.api_token)


### PR DESCRIPTION
- Make all API routes start with `/api`
- Add a route to compare result sets of two diferent tags
  - This endpoint supports both markdown (.text) and json (.json) output
- Add a create project link on projects/index
- Show `project name (UUID)` on projects/index (previously `UUID`)
