### PR TITLE
On example overview, allow filtering on tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,8 @@ gem 'coffee-rails', github: "rails/coffee-rails"
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
-gem 'turbolinks' 
+gem 'turbolinks'
+gem 'jquery-turbolinks'
 gem 'stronger_parameters', '~> 2.4.0'
 
 # Use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,9 @@ GEM
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-turbolinks (2.1.0)
+      railties (>= 3.1.0)
+      turbolinks
     json (1.8.3)
     jwt (1.5.2)
     listen (3.0.4)
@@ -300,6 +303,7 @@ DEPENDENCIES
   friendly_id
   guard-rspec
   jquery-rails
+  jquery-turbolinks
   omniauth
   omniauth-github
   pg

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,6 +11,7 @@
 // about supported directives.
 //
 //= require jquery
+//= require jquery.turbolinks
 //= require jquery_ujs
 //= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/dropdown.js
+++ b/app/assets/javascripts/dropdown.js
@@ -1,0 +1,6 @@
+$(document).ready(function() {
+	$('.filter-button').click(function(e) {
+		elem = $(e.target);
+		elem.parent().find('.filter-dropdown').slideToggle();
+	});
+});

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -21,3 +21,11 @@
 .green {
   color: green
 }
+
+.filter-dropdown {
+  display: none;
+}
+
+.filter-dropdown a {
+  display: block;
+}

--- a/app/controllers/examples_controller.rb
+++ b/app/controllers/examples_controller.rb
@@ -7,6 +7,7 @@ class ExamplesController < ApplicationController
 
     @last_result_for_this_example = last_result_for_this_example
     @results_for_this_example = results_for_this_example
+    @possible_tags = possible_tags
   end
 
   private
@@ -29,16 +30,27 @@ class ExamplesController < ApplicationController
     params['project_id']
   end
 
+  def tag
+    params['tag']
+  end
+
   delegate :results, to: :project
 
   def results_for_this_example
     @results_for_this_example ||= results
-      .where(example_name: example_name)
-      .order(created_at: :desc)
+    .optionally_with_tag(tag)
+    .where(example_name: example_name)
+    .order(created_at: :desc)
   end
 
   def project
     current_user.projects.find project_id
   end
-end
 
+  def possible_tags
+    results
+    .where(example_name: example_name)
+    .pluck(:tag)
+    .uniq
+  end
+end

--- a/app/views/examples/show.html.erb
+++ b/app/views/examples/show.html.erb
@@ -8,14 +8,25 @@
   </dl>
 <div>
 
+<div>
+  <button type="button" class="filter-button">Filter on tag</button>
+  <div class="filter-dropdown">
+    <%= link_to('(None)', params.merge(tag: '')) %>
+    <br/>
+    <% @possible_tags.each do |tag| %>
+      <%= link_to(tag, params.merge(tag: tag)) %>
+    <% end %>
+  </div>
+</div>
+
 
 <div>
   <table>
-
     <% @results_viewer.each_with_maybe_previous do |previous_result, result, query_change| %>
       <tr>
         <td><%= result.created_at %></td>
         <td><%= result.queries_count %></td>
+        <td><%= result.tag %></td>
 
         <% if previous_result.present? %>
           <% if query_change < 0 %>


### PR DESCRIPTION
- On the example overview (My projects -> <a project> -> <an example>), a button "filter on tag" has been added
  - This button shows a dropdown of links, the link takes you to the
    same page but filtered with the selected tag.
- On the same page, the examples' tags have been added to the table overview

![2016-01-06-125141_427x154_scrot](https://cloud.githubusercontent.com/assets/2501554/12141923/22996286-b474-11e5-9d87-9c97ccd1f32e.png)
