### PR TITLE
Add a link to the web interface during comparison

### DIFF
--- a/app/helpers/api/results_comper.rb
+++ b/app/helpers/api/results_comper.rb
@@ -21,7 +21,7 @@ module Api
 
         next if queries_that_got_added.empty? && queries_that_got_removed.empty?
 
-        format_comparison(left_result, queries_that_got_added, queries_that_got_removed)
+        format_comparison(left_result, right_result, queries_that_got_added, queries_that_got_removed)
       end.compact
     end
 
@@ -39,6 +39,7 @@ module Api
       header = "* #{result['example_name']} (#{result['example_location']})"
 
       markdown = <<-ENDMARKDOWN
+        * [View in web interface](#{result['web_interface_link']})
         * Queries that got added:
           #{array_to_markdown_list(result['queries_that_got_added'])}
         * Queries that got removed:
@@ -78,13 +79,20 @@ module Api
       end
     end
 
-    def format_comparison(left_result, queries_that_got_added, queries_that_got_removed)
+    def format_comparison(left_result, right_result, queries_that_got_added, queries_that_got_removed)
       {
         "example_name" => left_result.example_name,
         "example_location" => left_result.example_location,
         "queries_that_got_added" => queries_that_got_added,
         "queries_that_got_removed" => queries_that_got_removed,
+        "web_interface_link" => result_comparison_link(left_result, right_result),
       }
+    end
+
+    def result_comparison_link(left, right)
+      url_options = ActionController::Base.default_url_options
+      host = "#{url_options[:protocol]}://#{url_options[:host]}"
+      "#{host}/results/compare?result_id_left=#{left.id}&result_id_right=#{right.id}"
     end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -50,5 +50,6 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.default_url_options = { host: 'localhost:3000', protocol: 'http' }
+  config.action_controller.default_url_options = config.action_mailer.default_url_options
 end

--- a/spec/controllers/api/results_controller_spec.rb
+++ b/spec/controllers/api/results_controller_spec.rb
@@ -96,11 +96,15 @@ RSpec.describe Api::ResultsController, :type => :controller do
           create :query, result: result_left, statement: 'new query'
           create :query, result: result_right, statement: 'removed query'
 
+          web_interface_link = ":///results/compare?result_id_left="\
+            "#{result_left.id}&result_id_right=#{result_right.id}"
+
           expect(response_json).to eq 'results' => [{
             'example_name' => 'shared example name',
             'example_location' => 'spec/shared/example/location.rb',
             'queries_that_got_added' => ['new query'],
-            'queries_that_got_removed' => ['removed query']
+            'queries_that_got_removed' => ['removed query'],
+            'web_interface_link' => web_interface_link,
           }]
         end
       end


### PR DESCRIPTION
This diff generates a link to the web interface's result comparison, and
adds it to both the JSON and markdown output.
